### PR TITLE
Use http.ServeContent + add ETag header

### DIFF
--- a/hashfs_test.go
+++ b/hashfs_test.go
@@ -172,6 +172,8 @@ func TestFileServer(t *testing.T) {
 			t.Fatalf("content-type=%v, want %v", got, want)
 		} else if got, want := hdr.Get("Content-Length"), `13`; got != want {
 			t.Fatalf("content-length=%v, want %v", got, want)
+		} else if got, want := hdr.Get("ETag"), ""; got != want {
+			t.Fatalf("etag=%v, want %v", got, want)
 		} else if got, want := w.Body.String(), `<html></html>`; got != want {
 			t.Fatalf("body=%q, want %q", got, want)
 		}
@@ -183,6 +185,8 @@ func TestFileServer(t *testing.T) {
 		h := hashfs.FileServer(fsys)
 		h.ServeHTTP(w, r)
 
+		hash := "\"b633a587c652d02386c4f16f8c6f6aab7352d97f16367c3c40576214372dd628\""
+
 		hdr := w.Result().Header
 		if got, want := w.Code, 200; got != want {
 			t.Fatalf("code=%v, want %v", got, want)
@@ -192,6 +196,8 @@ func TestFileServer(t *testing.T) {
 			t.Fatalf("content-type=%v, want %v", got, want)
 		} else if got, want := hdr.Get("Content-Length"), `13`; got != want {
 			t.Fatalf("content-length=%v, want %v", got, want)
+		} else if got, want := hdr.Get("ETag"), hash; got != want {
+			t.Fatalf("etag=%v, want %v", got, want)
 		} else if got, want := w.Body.String(), `<html></html>`; got != want {
 			t.Fatalf("body=%q, want %q", got, want)
 		}


### PR DESCRIPTION
1. **Use http.ServeContent instead of io.Copy**

http.ServeContent replies to the request using the content in the provided ReadSeeker. The main benefit of http.ServeContent over io.Copy is that it handles Range requests properly, sets the MIME type, and handles If-Match, If-Unmodified-Since, If-None-Match, If-Modified-Since, and If-Range requests.

https://pkg.go.dev/net/http#ServeContent

2. **Add ETag header**

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/ETag