### PR TITLE
Fix README Handle path

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ hashfs
 Implementation of io/fs.FS that appends SHA256 hashes to filenames to allow for
 aggressive HTTP caching.
 
-For example, given a file path of `/scripts/main.js`, the `hashfs.FS`
+For example, given a file path of `scripts/main.js`, the `hashfs.FS`
 filesystem will provide the server with a hashname of
-`/scripts/main-b633a..d628.js`. Note the hash is truncated for brevity. When
+`scripts/main-b633a..d628.js` (the hash is truncated for brevity in the example). When
 this file path is requested by the client, the server can verify the hash and
 return the contents with an aggressive `Cache-Control` header. The client will
 cache this file for up to a year and does not need to re-request it in the
@@ -29,7 +29,7 @@ var fsys = hashfs.NewFS(embedFS)
 Then attach a `hashfs.FileServer()` to your router:
 
 ```go
-http.Handle("/assets", http.StripPrefix("/assets", hashfs.FileServer(fsys)))
+http.Handle("/assets/", http.StripPrefix("/assets/", hashfs.FileServer(fsys)))
 ```
 
 Next, your html templating library can obtain the hashname of your file using
@@ -38,7 +38,7 @@ the `hashfs.FS.HashName()` method:
 ```go
 func renderHTML(w io.Writer) {
 	fmt.Fprintf(w, `<html>`)
-	fmt.Fprintf(w, `<script script="/assets/%s">`, fsys.HashName("scripts/main.js"))
+	fmt.Fprintf(w, `<script src="/assets/%s"></script>`, fsys.HashName("scripts/main.js"))
 	fmt.Fprintf(w, `</html>`)
 }
 ```


### PR DESCRIPTION
Thanks for this package! I was surprised `embed` didn't do something like this by default, and then I found the [issue](https://github.com/golang/go/issues/43223) related to that that was closed. In any case, this PR just fixes a typo in the `http.Handle` path in the example in the README.

The main fix here is to add a trailing "/" to the `Handle` path -- without the trailing slash, `Handle` only handles the exact path "/assets", not "/assets/*".

The `StripPrefix` path doesn't strictly need the trailing slash, but it's less confusing if they match.

Also fix the `<script>` tag so it actually works (though I realize that's not the point of this example).